### PR TITLE
Add wireframe toggle using F1

### DIFF
--- a/src/engine/core/InputManager.cpp
+++ b/src/engine/core/InputManager.cpp
@@ -1,10 +1,12 @@
 #include "InputManager.h"
+#include <glad/glad.h>
 
 // Initialize static variables
 Camera* InputManager::s_Camera = nullptr;
 float InputManager::s_LastX = 0.0f;
 float InputManager::s_LastY = 0.0f;
 bool InputManager::s_FirstMouse = true;
+bool InputManager::s_Wireframe = false;
 
 void InputManager::Init(GLFWwindow* window) {
     // Set the static member variables for screen dimensions
@@ -35,7 +37,10 @@ void InputManager::SetCamera(Camera* camera) {
 
 // --- GLFW Callbacks ---
 void InputManager::key_callback(GLFWwindow* window, int key, int scancode, int action, int mods) {
-    // Here you could handle single-press key events in the future
+    if (key == GLFW_KEY_F1 && action == GLFW_PRESS) {
+        s_Wireframe = !s_Wireframe;
+        glPolygonMode(GL_FRONT_AND_BACK, s_Wireframe ? GL_LINE : GL_FILL);
+    }
 }
 
 void InputManager::mouse_callback(GLFWwindow* window, double xpos, double ypos) {

--- a/src/engine/core/InputManager.h
+++ b/src/engine/core/InputManager.h
@@ -26,6 +26,8 @@ private:
     static float s_LastX;
     static float s_LastY;
     static bool s_FirstMouse;
+    // Tracks the current polygon mode
+    static bool s_Wireframe;
 };
 
 #endif


### PR DESCRIPTION
## Summary
- allow switching between filled and wireframe rendering modes

## Testing
- `cmake ..` *(fails: glad.c missing)*

------
https://chatgpt.com/codex/tasks/task_e_6889cfe1cf908324ab329001eb49cb2b