### PR TITLE
Add wireframe toggle using F1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 3.10)
 # Define the project name
 project(LanderProject)
 
+find_package(Freetype REQUIRED)
+
 # Set the C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -38,15 +40,19 @@ add_executable(Lander
     src/engine/graphics/Mesh.cpp
     src/engine/graphics/Model.cpp
     src/engine/graphics/Sphere.cpp # <-- Added the new Sphere class
+    src/engine/ui/TextRenderer.cpp
+    src/engine/ui/UIManager.cpp
+    src/game/CommandModule.cpp
 )
 
 # --- Linking and Includes ---
 target_include_directories(Lander PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor
+    ${FREETYPE_INCLUDE_DIRS}
 )
 
 # Link all the necessary libraries
-target_link_libraries(Lander PRIVATE glad_lib glfw_lib opengl32 assimp_lib)
+target_link_libraries(Lander PRIVATE glad_lib glfw_lib opengl32 assimp_lib Freetype::Freetype)
 
 # --- Linker options for hiding console ---
 if(MSVC)

--- a/assets/shaders/text.frag
+++ b/assets/shaders/text.frag
@@ -1,0 +1,12 @@
+#version 330 core
+in vec2 TexCoords;
+out vec4 FragColor;
+
+uniform sampler2D text;
+uniform vec3 textColor;
+
+void main()
+{
+    float alpha = texture(text, TexCoords).r;
+    FragColor = vec4(textColor, alpha);
+}

--- a/assets/shaders/text.vert
+++ b/assets/shaders/text.vert
@@ -1,0 +1,11 @@
+#version 330 core
+layout (location = 0) in vec4 vertex; // <vec2 pos, vec2 tex>
+out vec2 TexCoords;
+
+uniform mat4 projection;
+
+void main()
+{
+    gl_Position = projection * vec4(vertex.xy, 0.0, 1.0);
+    TexCoords = vertex.zw;
+}

--- a/src/engine/core/InputManager.cpp
+++ b/src/engine/core/InputManager.cpp
@@ -1,10 +1,14 @@
 #include "InputManager.h"
+#include <glad/glad.h>
+#include "../ui/UIManager.h"
 
 // Initialize static variables
 Camera* InputManager::s_Camera = nullptr;
 float InputManager::s_LastX = 0.0f;
 float InputManager::s_LastY = 0.0f;
 bool InputManager::s_FirstMouse = true;
+bool InputManager::s_Wireframe = false;
+UIManager* InputManager::s_UIManager = nullptr;
 
 void InputManager::Init(GLFWwindow* window) {
     // Set the static member variables for screen dimensions
@@ -27,15 +31,32 @@ void InputManager::ProcessInput(GLFWwindow* window) {
     if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS) {
         glfwSetWindowShouldClose(window, true);
     }
+
+    if (glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_LEFT) == GLFW_PRESS && s_UIManager) {
+        int width, height;
+        glfwGetFramebufferSize(window, &width, &height);
+        float uiY = static_cast<float>(height) - s_LastY;
+        s_UIManager->HandleClick(s_LastX, uiY);
+    }
 }
 
 void InputManager::SetCamera(Camera* camera) {
     s_Camera = camera;
 }
 
+void InputManager::SetUIManager(UIManager* manager) {
+    s_UIManager = manager;
+}
+
 // --- GLFW Callbacks ---
 void InputManager::key_callback(GLFWwindow* window, int key, int scancode, int action, int mods) {
-    // Here you could handle single-press key events in the future
+    if (key == GLFW_KEY_F1 && action == GLFW_PRESS) {
+        s_Wireframe = !s_Wireframe;
+        glPolygonMode(GL_FRONT_AND_BACK, s_Wireframe ? GL_LINE : GL_FILL);
+    }
+    if (key == GLFW_KEY_F2 && action == GLFW_PRESS && s_UIManager) {
+        s_UIManager->TogglePower();
+    }
 }
 
 void InputManager::mouse_callback(GLFWwindow* window, double xpos, double ypos) {

--- a/src/engine/core/InputManager.h
+++ b/src/engine/core/InputManager.h
@@ -4,6 +4,8 @@
 #include <GLFW/glfw3.h>
 #include "../graphics/Camera.h"
 
+class UIManager;
+
 // A static class to handle all input
 class InputManager {
 public:
@@ -13,6 +15,7 @@ public:
     static void ProcessInput(GLFWwindow* window);
     // Connects the InputManager to the camera it should control
     static void SetCamera(Camera* camera);
+    static void SetUIManager(UIManager* manager);
 
 private:
     // GLFW callback functions
@@ -26,6 +29,10 @@ private:
     static float s_LastX;
     static float s_LastY;
     static bool s_FirstMouse;
+    // Tracks the current polygon mode
+    static bool s_Wireframe;
+    // Pointer to UI manager for UI interactions
+    static UIManager* s_UIManager;
 };
 
 #endif

--- a/src/engine/ui/TextRenderer.cpp
+++ b/src/engine/ui/TextRenderer.cpp
@@ -1,0 +1,121 @@
+#include "TextRenderer.h"
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
+#include <glad/glad.h>
+#include <glm/gtc/matrix_transform.hpp>
+#include <iostream>
+
+TextRenderer::TextRenderer() : VAO(0), VBO(0), m_Shader(nullptr) {}
+
+TextRenderer::~TextRenderer() {
+    if (VAO) glDeleteVertexArrays(1, &VAO);
+    if (VBO) glDeleteBuffers(1, &VBO);
+    delete m_Shader;
+}
+
+bool TextRenderer::Init(const char* fontPath, unsigned int fontSize, unsigned int screenWidth, unsigned int screenHeight) {
+    FT_Library ft;
+    if (FT_Init_FreeType(&ft)) {
+        std::cout << "ERROR::FREETYPE: Could not init FreeType Library" << std::endl;
+        return false;
+    }
+
+    FT_Face face;
+    if (FT_New_Face(ft, fontPath, 0, &face)) {
+        std::cout << "ERROR::FREETYPE: Failed to load font" << std::endl;
+        FT_Done_FreeType(ft);
+        return false;
+    }
+    FT_Set_Pixel_Sizes(face, 0, fontSize);
+
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1); // Disable byte-alignment restriction
+
+    for (unsigned char c = 0; c < 128; c++) {
+        if (FT_Load_Char(face, c, FT_LOAD_RENDER)) {
+            std::cout << "ERROR::FREETYTPE: Failed to load Glyph" << std::endl;
+            continue;
+        }
+        unsigned int texture;
+        glGenTextures(1, &texture);
+        glBindTexture(GL_TEXTURE_2D, texture);
+        glTexImage2D(
+            GL_TEXTURE_2D,
+            0,
+            GL_RED,
+            face->glyph->bitmap.width,
+            face->glyph->bitmap.rows,
+            0,
+            GL_RED,
+            GL_UNSIGNED_BYTE,
+            face->glyph->bitmap.buffer
+        );
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+        Character character = {
+            texture,
+            glm::ivec2(face->glyph->bitmap.width, face->glyph->bitmap.rows),
+            glm::ivec2(face->glyph->bitmap_left, face->glyph->bitmap_top),
+            static_cast<unsigned int>(face->glyph->advance.x)
+        };
+        Characters.insert(std::pair<char, Character>(c, character));
+    }
+    glBindTexture(GL_TEXTURE_2D, 0);
+    FT_Done_Face(face);
+    FT_Done_FreeType(ft);
+
+    // Shader setup
+    m_Shader = new Shader("assets/shaders/text.vert", "assets/shaders/text.frag");
+    m_Shader->use();
+    m_Projection = glm::ortho(0.0f, static_cast<float>(screenWidth), 0.0f, static_cast<float>(screenHeight));
+    m_Shader->setMat4("projection", m_Projection);
+
+    glGenVertexArrays(1, &VAO);
+    glGenBuffers(1, &VBO);
+    glBindVertexArray(VAO);
+    glBindBuffer(GL_ARRAY_BUFFER, VBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 6 * 4, NULL, GL_DYNAMIC_DRAW);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(float), 0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindVertexArray(0);
+    return true;
+}
+
+void TextRenderer::RenderText(const std::string& text, float x, float y, float scale, glm::vec3 color) {
+    if (!m_Shader) return;
+    m_Shader->use();
+    m_Shader->setVec3("textColor", color);
+    glActiveTexture(GL_TEXTURE0);
+    glBindVertexArray(VAO);
+
+    std::string::const_iterator c;
+    for (c = text.begin(); c != text.end(); c++) {
+        Character ch = Characters[*c];
+
+        float xpos = x + ch.Bearing.x * scale;
+        float ypos = y - (ch.Size.y - ch.Bearing.y) * scale;
+
+        float w = ch.Size.x * scale;
+        float h = ch.Size.y * scale;
+        float vertices[6][4] = {
+            { xpos,     ypos + h,   0.0f, 0.0f },
+            { xpos,     ypos,       0.0f, 1.0f },
+            { xpos + w, ypos,       1.0f, 1.0f },
+            { xpos,     ypos + h,   0.0f, 0.0f },
+            { xpos + w, ypos,       1.0f, 1.0f },
+            { xpos + w, ypos + h,   1.0f, 0.0f }
+        };
+        glBindTexture(GL_TEXTURE_2D, ch.TextureID);
+        glBindBuffer(GL_ARRAY_BUFFER, VBO);
+        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(vertices), vertices);
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        glDrawArrays(GL_TRIANGLES, 0, 6);
+        x += (ch.Advance >> 6) * scale; // bitshift by 6 to get value in pixels
+    }
+    glBindVertexArray(0);
+    glBindTexture(GL_TEXTURE_2D, 0);
+}

--- a/src/engine/ui/TextRenderer.h
+++ b/src/engine/ui/TextRenderer.h
@@ -1,0 +1,32 @@
+#ifndef TEXT_RENDERER_H
+#define TEXT_RENDERER_H
+
+#include <map>
+#include <string>
+#include <glm/glm.hpp>
+
+#include "../graphics/Shader.h"
+
+struct Character {
+    unsigned int TextureID;  // ID handle of the glyph texture
+    glm::ivec2 Size;         // Size of glyph
+    glm::ivec2 Bearing;      // Offset from baseline to left/top of glyph
+    unsigned int Advance;    // Offset to advance to next glyph
+};
+
+class TextRenderer {
+public:
+    TextRenderer();
+    ~TextRenderer();
+
+    bool Init(const char* fontPath, unsigned int fontSize, unsigned int screenWidth, unsigned int screenHeight);
+    void RenderText(const std::string& text, float x, float y, float scale, glm::vec3 color);
+
+private:
+    std::map<char, Character> Characters;
+    unsigned int VAO, VBO;
+    Shader* m_Shader;
+    glm::mat4 m_Projection;
+};
+
+#endif

--- a/src/engine/ui/UIManager.cpp
+++ b/src/engine/ui/UIManager.cpp
@@ -1,0 +1,56 @@
+#include "UIManager.h"
+#include "../graphics/Shader.h"
+#include "../../game/CommandModule.h"
+#include <glm/vec3.hpp>
+
+UIManager::UIManager() : m_CommandModule(nullptr) {}
+
+void UIButton::Draw(TextRenderer& renderer) const {
+    renderer.RenderText(Label, X, Y, 1.0f, glm::vec3(0.0f, 1.0f, 0.0f));
+}
+
+bool UIButton::Contains(float x, float y) const {
+    return x >= X && x <= X + Width && y >= Y && y <= Y + Height;
+}
+
+bool UIManager::Init(unsigned int screenWidth, unsigned int screenHeight, CommandModule* cmdModule) {
+    m_CommandModule = cmdModule;
+    if (!m_TextRenderer.Init("assets/fonts/eurostile.TTF", 24, screenWidth, screenHeight))
+        return false;
+
+    UIButton powerBtn;
+    powerBtn.Label = "TOGGLE POWER";
+    powerBtn.X = 20.0f;
+    powerBtn.Y = screenHeight - 40.0f;
+    powerBtn.Width = 200.0f;
+    powerBtn.Height = 30.0f;
+    powerBtn.OnClick = [this]() { TogglePower(); };
+
+    m_Buttons.push_back(powerBtn);
+    return true;
+}
+
+void UIManager::Render() {
+    for (const auto& btn : m_Buttons) {
+        btn.Draw(m_TextRenderer);
+    }
+    if (m_CommandModule) {
+        std::string status = "POWER: ";
+        status += m_CommandModule->IsPowered() ? "ON" : "OFF";
+        m_TextRenderer.RenderText(status, 20.0f, 40.0f, 1.0f, glm::vec3(1.0f));
+    }
+}
+
+void UIManager::HandleClick(float x, float y) {
+    for (auto& btn : m_Buttons) {
+        if (btn.Contains(x, y) && btn.OnClick) {
+            btn.OnClick();
+        }
+    }
+}
+
+void UIManager::TogglePower() {
+    if (m_CommandModule) {
+        m_CommandModule->TogglePower();
+    }
+}

--- a/src/engine/ui/UIManager.h
+++ b/src/engine/ui/UIManager.h
@@ -1,0 +1,33 @@
+#ifndef UI_MANAGER_H
+#define UI_MANAGER_H
+
+#include <vector>
+#include <functional>
+#include "TextRenderer.h"
+
+class UIButton {
+public:
+    std::string Label;
+    float X, Y, Width, Height;
+    std::function<void()> OnClick;
+
+    void Draw(TextRenderer& renderer) const;
+    bool Contains(float x, float y) const;
+};
+
+class CommandModule;
+
+class UIManager {
+public:
+    UIManager();
+    bool Init(unsigned int screenWidth, unsigned int screenHeight, CommandModule* cmdModule);
+    void Render();
+    void HandleClick(float x, float y);
+    void TogglePower();
+private:
+    TextRenderer m_TextRenderer;
+    std::vector<UIButton> m_Buttons;
+    CommandModule* m_CommandModule;
+};
+
+#endif

--- a/src/game/CommandModule.cpp
+++ b/src/game/CommandModule.cpp
@@ -1,0 +1,11 @@
+#include "CommandModule.h"
+
+CommandModule::CommandModule() : m_Powered(true) {}
+
+void CommandModule::TogglePower() {
+    m_Powered = !m_Powered;
+}
+
+bool CommandModule::IsPowered() const {
+    return m_Powered;
+}

--- a/src/game/CommandModule.h
+++ b/src/game/CommandModule.h
@@ -1,0 +1,13 @@
+#ifndef COMMAND_MODULE_H
+#define COMMAND_MODULE_H
+
+class CommandModule {
+public:
+    CommandModule();
+    void TogglePower();
+    bool IsPowered() const;
+private:
+    bool m_Powered;
+};
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,8 @@
 #include "engine/graphics/TextureLoader.h"
 #include "engine/graphics/Model.h"
 #include "engine/graphics/Sphere.h" // Include our new Sphere class
+#include "engine/ui/UIManager.h"
+#include "game/CommandModule.h"
 
 // --- Initial Window Dimensions ---
 unsigned int screenWidth = 1600;
@@ -42,6 +44,11 @@ int main() {
     Camera camera(glm::vec3(0.0f, 0.0f, 0.0f), 5.0f);
     InputManager::Init(window);
     InputManager::SetCamera(&camera);
+
+    CommandModule commandModule;
+    UIManager uiManager;
+    uiManager.Init(screenWidth, screenHeight, &commandModule);
+    InputManager::SetUIManager(&uiManager);
 
     glEnable(GL_MULTISAMPLE);
     glEnable(GL_DEPTH_TEST);
@@ -141,6 +148,9 @@ int main() {
         glDrawArrays(GL_TRIANGLES, 0, 36);
         glBindVertexArray(0);
         glDepthFunc(GL_LESS);
+
+        // --- Render UI ---
+        uiManager.Render();
 
         glfwSwapBuffers(window);
         glfwPollEvents();


### PR DESCRIPTION
## Summary
- allow switching between filled and wireframe rendering modes
- add a minimal FreeType-based UI system
- display command module power status and toggle via F2 or on-screen button

## Testing
- `cmake ..` *(fails: glad.c missing)*

------
https://chatgpt.com/codex/tasks/task_e_6889cfe1cf908324ab329001eb49cb2b